### PR TITLE
Update travis-ci Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "0.6"
-  - "0.8"
   - "0.10"
+  - "0.12"


### PR DESCRIPTION
The last 0.8 update was over two years ago. Getting with the times.

Many tests fail in 4.0+ because ES6 is the new black.