### PR TITLE
Revert "Browserify"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 npm-debug.log
-/dist/

--- a/README.md
+++ b/README.md
@@ -140,13 +140,12 @@ This implementation’s own [package.json5](package.json5) is more realistic:
     dependencies: {},
     devDependencies: {
         gulp: '^3.9.0',
-        'gulp-browserify': "^0.5.1",
         'gulp-jshint': '^1.11.2',
         'jshint-stylish': '^2.0.1',
         mocha: '~1.0.3',    // TODO: Look into Mocha v2.
     },
     scripts: {
-        build: 'node ./lib/cli.js -c package.json5 && gulp',
+        build: 'node ./lib/cli.js -c package.json5',
         test: 'mocha --ui exports --reporter spec',
             // TODO: Would it be better to define these in a mocha.opts file?
     },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,17 +1,8 @@
 var gulp = require('gulp');
 var jshint = require('gulp-jshint');
-var browserify = require('gulp-browserify');
 
 gulp.task('lint', function() {
-    return gulp.src('./lib/*.js')
-        .pipe(jshint())
-        .pipe(jshint.reporter('jshint-stylish'));
+  return gulp.src('./lib/*.js')
+    .pipe(jshint())
+    .pipe(jshint.reporter('jshint-stylish'));
 });
-
-gulp.task('browserify', function() {
-    return gulp.src('./lib/json5.js')
-        .pipe(browserify())
-        .pipe(gulp.dest('./dist/'));
-});
-
-gulp.task('default', ['lint', 'browserify']);

--- a/package.json
+++ b/package.json
@@ -17,13 +17,12 @@
     "dependencies": {},
     "devDependencies": {
         "gulp": "^3.9.0",
-        "gulp-browserify": "^0.5.1",
         "gulp-jshint": "^1.11.2",
         "jshint-stylish": "^2.0.1",
         "mocha": "~1.0.3"
     },
     "scripts": {
-        "build": "node ./lib/cli.js -c package.json5 && gulp",
+        "build": "node ./lib/cli.js -c package.json5",
         "test": "mocha --ui exports --reporter spec"
     },
     "homepage": "http://json5.org/",

--- a/package.json5
+++ b/package.json5
@@ -19,13 +19,12 @@
     dependencies: {},
     devDependencies: {
         gulp: '^3.9.0',
-        'gulp-browserify': "^0.5.1",
         'gulp-jshint': '^1.11.2',
         'jshint-stylish': '^2.0.1',
         mocha: '~1.0.3',    // TODO: Look into Mocha v2.
     },
     scripts: {
-        build: 'node ./lib/cli.js -c package.json5 && gulp',
+        build: 'node ./lib/cli.js -c package.json5',
         test: 'mocha --ui exports --reporter spec',
             // TODO: Would it be better to define these in a mocha.opts file?
     },


### PR DESCRIPTION
Reverting because gulp-browserify doesn't support the standalone option, which we need. The Browserify portions of #89 may be implemented instead.