### PR TITLE
Add support for line and column number context for errors: #86

### DIFF
--- a/lib/json5.js
+++ b/lib/json5.js
@@ -17,8 +17,10 @@ JSON5.parse = (function () {
 // We are defining the function inside of another function to avoid creating
 // global variables.
 
-    var at,     // The index of the current character
-        ch,     // The current character
+    var at,           // The index of the current character
+        lineNumber,   // The current line number
+        columnNumber, // The current column number
+        ch,           // The current character
         escapee = {
             "'":  "'",
             '"':  '"',
@@ -43,14 +45,22 @@ JSON5.parse = (function () {
         ],
         text,
 
+        renderChar = function (chr) {
+            return chr === '' ? 'EOF' : "'" + chr + "'";
+        },
+
         error = function (m) {
 
 // Call error when something is wrong.
 
             var error = new SyntaxError();
-            error.message = m;
+            // beginning of message suffix to agree with that provided by Gecko - see https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
+            error.message = m + " at line " + lineNumber + " column " + columnNumber + " of the JSON5 data. Still to read: " + JSON.stringify(text.substring(at - 1, at + 19));
             error.at = at;
-            error.text = text;
+            // These two property names have been chosen to agree with the ones in Gecko, the only popular
+            // environment which seems to supply this info on JSON.parse
+            error.lineNumber = lineNumber;
+            error.columnNumber = columnNumber;
             throw error;
         },
 
@@ -59,14 +69,19 @@ JSON5.parse = (function () {
 // If a c parameter is provided, verify that it matches the current character.
 
             if (c && c !== ch) {
-                error("Expected '" + c + "' instead of '" + ch + "'");
+                error("Expected " + renderChar(c) + " instead of " + renderChar(ch));
             }
 
 // Get the next character. When there are no more characters,
 // return the empty string.
 
             ch = text.charAt(at);
-            at += 1;
+            ++ at;
+            ++ columnNumber;
+            if (ch === '\n') {
+                ++ lineNumber;
+                columnNumber = 0;
+            }
             return ch;
         },
 
@@ -94,7 +109,7 @@ JSON5.parse = (function () {
             if ((ch !== '_' && ch !== '$') &&
                     (ch < 'a' || ch > 'z') &&
                     (ch < 'A' || ch > 'Z')) {
-                error("Bad identifier");
+                error("Bad identifier as unquoted key");
             }
 
             // Subsequent characters can contain digits.
@@ -375,7 +390,7 @@ JSON5.parse = (function () {
               next( 'N' );
               return NaN;
             }
-            error("Unexpected '" + ch + "'");
+            error("Unexpected " + renderChar(ch));
         },
 
         value,  // Place holder for the value function.
@@ -487,6 +502,8 @@ JSON5.parse = (function () {
 
         text = String(source);
         at = 0;
+        lineNumber = 1;
+        columnNumber = 1;
         ch = ' ';
         result = value();
         white();

--- a/lib/json5.js
+++ b/lib/json5.js
@@ -40,6 +40,8 @@ JSON5.parse = (function () {
             '\n',
             '\v',
             '\f',
+            '\u2028',
+            '\u2029',
             '\xA0',
             '\uFEFF'
         ],
@@ -76,10 +78,11 @@ JSON5.parse = (function () {
 // return the empty string.
 
             ch = text.charAt(at);
-            ++ at;
-            ++ columnNumber;
-            if (ch === '\n') {
-                ++ lineNumber;
+            at++;
+            columnNumber++;
+            var ch2 = text.charAt(at);
+            if (ch === '\n' || ch === '\u2028' || ch === '\u2029' || ch === '\r' && ch2 !== '\n') {
+                lineNumber++;
                 columnNumber = 0;
             }
             return ch;

--- a/lib/json5.js
+++ b/lib/json5.js
@@ -40,8 +40,6 @@ JSON5.parse = (function () {
             '\n',
             '\v',
             '\f',
-            '\u2028',
-            '\u2029',
             '\xA0',
             '\uFEFF'
         ],
@@ -80,8 +78,7 @@ JSON5.parse = (function () {
             ch = text.charAt(at);
             at++;
             columnNumber++;
-            var ch2 = text.charAt(at);
-            if (ch === '\n' || ch === '\u2028' || ch === '\u2029' || ch === '\r' && ch2 !== '\n') {
+            if (ch === '\n' || ch === '\r' && peek() !== '\n') {
                 lineNumber++;
                 columnNumber = 0;
             }

--- a/test/count-newlines.js
+++ b/test/count-newlines.js
@@ -1,0 +1,43 @@
+// count-newlines.js
+// Tests JSON5's line counting algorithm's support for all the varieties of newlines supported in ES5.
+// These are described at https://es5.github.io/#x7.3
+
+// Note that the two special separators, LS and PS are not part of JSON but we recognise them as part of 
+// our wider mission to extend the JSON subset towards the ES5 subset - 
+// see http://timelessrepo.com/json-isnt-a-javascript-subset
+
+"use strict";
+
+var assert = require('assert');
+var JSON5 = require('..');
+
+// Each of these cases should give rise to a parse error with the same coordinates
+var cases = {
+    LF:   "{\u000a    10thing",
+    CRLF: "{\u000d\u000a    10thing",
+    CR:   "{\u000d    10thing",
+    LS:   "{\u2028    10thing",
+    PS:   "{\u2029    10thing"
+};
+
+var spec = {
+    lineNumber: 2,
+    columnNumber: 5
+};
+
+exports['count-newlines'] = {};
+
+Object.keys(cases).forEach(function (key) {
+    var str = cases[key];
+    exports['count-newlines'][key] = function () {
+        var err;
+        try {
+            JSON5.parse(str);
+        } catch (e) {
+            err = e;
+        }
+        assert(err, 'Expected JSON5 parsing to fail.');
+        assert.equal(err.lineNumber, spec.lineNumber);
+        assert.equal(err.columnNumber, spec.columnNumber);
+    };
+});

--- a/test/count-newlines.js
+++ b/test/count-newlines.js
@@ -1,10 +1,6 @@
 // count-newlines.js
-// Tests JSON5's line counting algorithm's support for all the varieties of newlines supported in ES5.
-// These are described at https://es5.github.io/#x7.3
-
-// Note that the two special separators, LS and PS are not part of JSON but we recognise them as part of 
-// our wider mission to extend the JSON subset towards the ES5 subset - 
-// see http://timelessrepo.com/json-isnt-a-javascript-subset
+// Tests JSON5's line counting algorithm's support for the basic varieties of newline that we support - 
+// LF, CR+LF and CR
 
 "use strict";
 
@@ -15,9 +11,7 @@ var JSON5 = require('..');
 var cases = {
     LF:   "{\u000a    10thing",
     CRLF: "{\u000d\u000a    10thing",
-    CR:   "{\u000d    10thing",
-    LS:   "{\u2028    10thing",
-    PS:   "{\u2029    10thing"
+    CR:   "{\u000d    10thing"
 };
 
 var spec = {

--- a/test/parse-cases/arrays/no-comma-array.errorSpec
+++ b/test/parse-cases/arrays/no-comma-array.errorSpec
@@ -1,0 +1,6 @@
+{
+    at: 16,
+    lineNumber: 3,
+    columnNumber: 5,
+    message: "Expected ']' instead of 'f'"
+}

--- a/test/parse-cases/comments/top-level-block-comment.errorSpec
+++ b/test/parse-cases/comments/top-level-block-comment.errorSpec
@@ -1,0 +1,6 @@
+{
+    at: 77,
+    lineNumber: 4,
+    columnNumber: 3,
+    message: "Unexpected EOF"
+}

--- a/test/parse-cases/comments/top-level-block-comment.txt
+++ b/test/parse-cases/comments/top-level-block-comment.txt
@@ -1,4 +1,4 @@
 /*
     This should fail;
-    comments cannot be the top-level value.
+    comments cannot be the only top-level value.
 */

--- a/test/parse-cases/comments/top-level-inline-comment.errorSpec
+++ b/test/parse-cases/comments/top-level-inline-comment.errorSpec
@@ -1,0 +1,6 @@
+{
+    at: 66,
+    lineNumber: 1,
+    columnNumber: 67,
+    message: "Unexpected EOF"
+}

--- a/test/parse-cases/comments/top-level-inline-comment.txt
+++ b/test/parse-cases/comments/top-level-inline-comment.txt
@@ -1,1 +1,1 @@
-// This should fail; comments cannot be the top-level value.
+// This should fail; comments cannot be the only top-level value.

--- a/test/parse-cases/objects/illegal-unquoted-key-number.errorSpec
+++ b/test/parse-cases/objects/illegal-unquoted-key-number.errorSpec
@@ -1,0 +1,6 @@
+{
+    at: 7,
+    lineNumber: 2,
+    columnNumber: 5,
+    message: "Bad identifier as unquoted key"
+}

--- a/test/parse-cases/objects/illegal-unquoted-key-symbol.errorSpec
+++ b/test/parse-cases/objects/illegal-unquoted-key-symbol.errorSpec
@@ -1,0 +1,6 @@
+{
+    at: 12,
+    lineNumber: 2,
+    columnNumber: 10,
+    message: "Expected ':' instead of '-'"
+}

--- a/test/parse-cases/objects/leading-comma-object.errorSpec
+++ b/test/parse-cases/objects/leading-comma-object.errorSpec
@@ -1,0 +1,6 @@
+{
+    at: 7,
+    lineNumber: 2,
+    columnNumber: 5,
+    message: "Bad identifier as unquoted key"
+}

--- a/test/parse-cases/strings/no-comma-array.errorSpec
+++ b/test/parse-cases/strings/no-comma-array.errorSpec
@@ -1,0 +1,6 @@
+{
+    at: 16,
+    lineNumber: 3,
+    columNumber: 5,
+    message: "Expected ']' instead of 'f'"
+}

--- a/test/parse-cases/strings/unescaped-multi-line-string.errorSpec
+++ b/test/parse-cases/strings/unescaped-multi-line-string.errorSpec
@@ -1,0 +1,6 @@
+{
+    at: 5,
+    lineNumber: 2,
+    columnNumber: 0,
+    message: "Bad string"
+}

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,6 +1,8 @@
 // parse.js
 // Tests parse(). See readme.txt for details.
 
+"use strict";
+
 var assert = require('assert');
 var FS = require('fs');
 var JSON5 = require('..');

--- a/test/parse.js
+++ b/test/parse.js
@@ -19,6 +19,49 @@ var Path = require('path');
 var dirsPath = Path.resolve(__dirname, 'parse-cases');
 var dirs = FS.readdirSync(dirsPath);
 
+var readErrorSpec = function (filePath) {
+    var specName = Path.basename(filePath, '.txt') + '.errorSpec';
+    var specPath = Path.join(Path.dirname(filePath), specName);
+    var specTxt;
+    try {
+        specTxt = FS.readFileSync(specPath); // note that existsSync has been deprecated
+    } catch (e) {}
+    if (specTxt) {
+        try {
+            return JSON5.parse(specTxt);
+        } catch (err) {
+            err.message = 'Error reading error specification file ' + specName + ': ' + err.message;
+            throw err;
+        }
+    }
+};
+
+var testParseJSON5 = function (filePath, str) {
+    var errorSpec = readErrorSpec(filePath);
+    var err;
+    try {
+        JSON5.parse(str);
+    } catch (e) {
+        err = e;
+    }
+    assert(err, 'Expected JSON5 parsing to fail.');
+    if (errorSpec) {
+        describe("Error fixture " + filePath, function () {
+        Object.keys(errorSpec).forEach(function (key) {
+            if (key === 'message') {
+                it('Expected error message\n' + err.message + '\nto start with ' + errorSpec.message, function () {
+                    assert(err.message.indexOf(errorSpec.message) === 0);
+                });
+            } else {
+                it('Expected parse error field ' + key + ' to hold value ' + errorSpec[key], function () {
+                    assert.equal(err[key], errorSpec[key]);
+                });
+            }
+        })
+        });
+    }
+};
+
 function createTest(fileName, dir) {
     var ext = Path.extname(fileName);
     var filePath = Path.join(dirsPath, dir, fileName);
@@ -66,8 +109,7 @@ function createTest(fileName, dir) {
             case '.txt':
                 assert.throws(parseES5,         // test validation
                     'Test case bug: expected ES5 parsing to fail.');
-                assert.throws(parseJSON5,
-                    'Expected JSON5 parsing to fail.');
+                testParseJSON5(filePath, str);
                 break;
         }
     };

--- a/test/require.js
+++ b/test/require.js
@@ -5,6 +5,8 @@
 // - /parse-cases/misc/npm-package.json
 // - /parse-cases/misc/npm-package.json5
 
+"use strict";
+
 var assert = require('assert');
 
 exports['misc'] = {};

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1,7 +1,5 @@
 // tests stringify()
 
-/*global require console exports */
-
 // set to true to show performance stats
 var DEBUG = false;
 


### PR DESCRIPTION
Hi - here is my proposed fix for #86 introducing support for line and column numbers.

I've introduced a new "errorSpec" system which allows us to write little JSON5 files with the "errorSpec" suffix alongside parse fail ".txt" files holding assertions about the error contents - this will allow us to write tests for #69 easily if we want to address it later.

I'm sorry I had to subvert the "exports" style for mocha slightly since it didn't sit nicely with the dynamism relating to whether we have an errorSpec file or not - I could try harder to preserve it, but I think it might be a little messy either way.

Thanks for any feedback!