### PR TITLE
include only necessary files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     ],
     "main": "lib/json5.js",
     "bin": "lib/cli.js",
+    "files": ["lib/"],
     "dependencies": {},
     "devDependencies": {
         "gulp": "^3.9.0",


### PR DESCRIPTION
```
$ tree node_modules/json5 -I node_modules -L 3

node_modules/json5
├── lib/
│   ├── cli.js*
│   ├── json5.js
│   └── require.js
├── test/
│   ├── parse-cases/
│   │   ├── arrays/
│   │   ├── comments/
│   │   ├── misc/
│   │   ├── new-lines/
│   │   ├── numbers/
│   │   ├── objects/
│   │   ├── strings/
│   │   └── todo/
│   ├── parse.js
│   ├── readme.md
│   ├── require.js
│   └── stringify.js
├── .editorconfig
├── .npmignore
├── .travis.yml
├── CHANGELOG.md
├── README.md
├── package.json
└── package.json5
```

Loading unnecessary files is one of the reasons `npm install`s take so darn long. Anton Rudeshko very well put it in [his article](http://www.rudeshko.com/web/2014/05/13/help-people-consume-your-npm-packages.html):

> Speaking in terms of object-oriented design, your npm package should be [highly cohesive](https://en.wikipedia.org/wiki/Cohesion_(computer_science)) and [loosely coupled](https://en.wikipedia.org/wiki/Loose_coupling). Your package should do only one thing and do it well.

Corey Butler also wrote [a nice article](https://medium.com/@goldglovecb/npm-needs-a-personal-trainer-537e0f8859c6) about why it's important to minimize module footprints, including test suite:

> In the rare situation a developer actually wants to run your test suite on their own local computer, they'll likely clone or fork it.

Also see [NPM docs](https://docs.npmjs.com/files/package.json#files) for details about `files` field in `package.json`.