### PR TITLE
Explicitly declare peer dependency jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "devDependencies": {
         "gulp": "^3.9.1",
         "gulp-jshint": "^2.0.0",
+        "jshint": "^2.9.1",
         "jshint-stylish": "^2.1.0",
         "mocha": "^2.4.5"
     },

--- a/package.json5
+++ b/package.json5
@@ -21,6 +21,7 @@
     devDependencies: {
         gulp: "^3.9.1",
         'gulp-jshint': "^2.0.0",
+        jshint: "^2.9.1",
         'jshint-stylish': "^2.1.0",
         mocha: "^2.4.5"
     },


### PR DESCRIPTION
Without this, npm v3 will not install jshint along with gulp-jshint.